### PR TITLE
Fixed dtype issue when using faiss-gpu

### DIFF
--- a/tabdpt.py
+++ b/tabdpt.py
@@ -182,7 +182,7 @@ class TabDPTRegressor(TabDPTEstimator, RegressorMixin):
                 end = min(len(self.X_test), (b + 1) * self.inf_batch_size)
 
                 indices_nni = self.faiss_knn.get_knn_indices(
-                    self.X_test[start:end], k=context_size
+                    self.X_test[start:end].astype(np.float32), k=context_size
                 )
                 X_nni = train_x[torch.tensor(indices_nni)]
                 y_nni = train_y[torch.tensor(indices_nni)]


### PR DESCRIPTION
Numpy vector needs to be of **dtype.float32** instead of **dtype.float64**, otherwise FAISS (faiss-gpu) will raise the following error: 
```bash
TypeError: in method 'IndexFlat_add', argument 3 of type 'float const *'
```