### PR TITLE
Enable flash attention and model compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,14 @@ print(r2_score(y_test, y_pred))
 ## Roadmap
 - [ ] Release other model sizes
 - [ ] Release training code
+
+
+## Update December 2024
+Support for bf16 precision and flash-attention is enabled and used by default. Added compilation option as well.
+
+### Example 
+```
+model = TabDPTClassifier(path='checkpoints/tabdpt_76M.ckpt', use_bf16=True, compile=False)
+```
+
+On very large datasets with large evaluation, faiss search might become the bottleneck. In that case an approximate index (IVF, HNSW) 

--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ Support for bf16 precision and flash-attention is enabled and used by default. A
 model = TabDPTClassifier(path='checkpoints/tabdpt_76M.ckpt', use_bf16=True, compile=False)
 ```
 
-On very large datasets with large evaluation, faiss search might become the bottleneck. In that case an approximate index (IVF, HNSW) 
+On very large datasets with large evaluation, faiss search might become the bottleneck. In that case an approximate index (IVF, HNSW) might be preferable.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ To run `TabDPT`, install the following packages:
 
 You need to also download the [weights below](#model-weights-download).
 
+### Update December 2024
+Added support for flash attention (with bf16 precision) and compile flag. Both are enabled to True by default and should lead to a significant speed-up.
+
 
 ## Example Usage 1
 ```
@@ -21,7 +24,7 @@ from tabdpt import TabDPTClassifier
 X, y = load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42)
 
-model = TabDPTClassifier(path='checkpoints/tabdpt_76M.ckpt')
+model = TabDPTClassifier(path='checkpoints/tabdpt_76M.ckpt', use_flash=True, compile=True)
 model.fit(X_train, y_train)
 y_pred = model.predict(X_test, temperature=0.8, context_size=1024)
 print(accuracy_score(y_test, y_pred))
@@ -51,14 +54,3 @@ print(r2_score(y_test, y_pred))
 ## Roadmap
 - [ ] Release other model sizes
 - [ ] Release training code
-
-
-## Update December 2024
-Support for bf16 precision and flash-attention is enabled and used by default. Added compilation option as well.
-
-### Example 
-```
-model = TabDPTClassifier(path='checkpoints/tabdpt_76M.ckpt', use_bf16=True, compile=False)
-```
-
-On very large datasets with large evaluation, faiss search might become the bottleneck. In that case an approximate index (IVF, HNSW) might be preferable.

--- a/tabdpt.py
+++ b/tabdpt.py
@@ -1,4 +1,5 @@
 import torch
+from torch.nn.attention import SDPBackend, sdpa_kernel
 import numpy as np
 import math
 import random
@@ -6,13 +7,13 @@ from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.utils.validation import check_is_fitted
 from sklearn.impute import SimpleImputer
 from sklearn.preprocessing import StandardScaler
-from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
 from tabdpt_model import TabDPTModel
 from utils import convert_to_torch_tensor, pad_x, FAISS, seed_everything
 
 
+
 class TabDPTEstimator(BaseEstimator):
-    def __init__(self, path: str, mode: str, inf_batch_size: int, device: str):
+    def __init__(self, path: str, mode: str, inf_batch_size: int, device: str, use_bf16: bool, compile: bool):
         self.mode = mode
         self.inf_batch_size = inf_batch_size
         self.device = device
@@ -21,6 +22,8 @@ class TabDPTEstimator(BaseEstimator):
         self.model.eval()
         self.max_features = self.model.num_features
         self.max_num_classes = self.model.n_out
+        self.use_bf16 = use_bf16
+        self.compile = compile
 
     def fit(self, X, y):
         assert isinstance(X, np.ndarray), "X must be a numpy array"
@@ -39,6 +42,11 @@ class TabDPTEstimator(BaseEstimator):
         self.X_train = X
         self.y_train = y
         self.is_fitted_ = True
+        if self.use_bf16:
+            self.autocast = torch.autocast(device_type='cuda', dtype=torch.bfloat16)
+
+        if self.compile:
+            self.model = torch.compile(self.model)
         
     def _prepare_prediction(self, X: np.ndarray):
         check_is_fitted(self)
@@ -62,8 +70,8 @@ class TabDPTEstimator(BaseEstimator):
 
 
 class TabDPTClassifier(TabDPTEstimator, ClassifierMixin):
-    def __init__(self, path: str, inf_batch_size: int = 512, device: str = 'cuda:0'):
-        super().__init__(path=path, mode='cls', inf_batch_size=inf_batch_size, device=device)
+    def __init__(self, path: str, inf_batch_size: int = 512, device: str = 'cuda:0', use_bf16: bool = True, compile: bool = False):
+        super().__init__(path=path, mode='cls', inf_batch_size=inf_batch_size, device=device, use_bf16=use_bf16, compile=compile)
         
     def fit(self, X, y):
         super().fit(X, y)
@@ -76,12 +84,20 @@ class TabDPTClassifier(TabDPTEstimator, ClassifierMixin):
         digit_preds = []
         for i in range(num_digits):
             y_train_digit = (y_train // (self.max_num_classes ** i)) % self.max_num_classes
-            pred = self.model(
-                x_src=torch.cat([X_train, X_test], dim=0),
-                y_src=y_train_digit,
-                task='cls',
-            )
-            digit_preds.append(pred)
+            if self.use_bf16:
+                with self.autocast, sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+                    pred = self.model(
+                        x_src=torch.cat([X_train, X_test], dim=0),
+                        y_src=y_train_digit,
+                        task='cls',
+                    )
+            else:
+                pred = self.model(
+                    x_src=torch.cat([X_train, X_test], dim=0),
+                    y_src=y_train_digit,
+                    task='cls',
+                )
+            digit_preds.append(pred.float())
 
         full_pred = torch.zeros((X_test.shape[0], X_test.shape[1], self.num_classes), device=X_train.device)
         for class_idx in range(self.num_classes):
@@ -135,15 +151,23 @@ class TabDPTClassifier(TabDPTEstimator, ClassifierMixin):
                 X_eval = pad_x(X_eval.unsqueeze(0), self.max_features).to(self.device)
                 
                 if self.num_classes <= self.max_num_classes:
-                    pred = self.model(
-                        x_src=torch.cat([X_nni, X_eval], dim=0),
-                        y_src=y_nni,
-                        task=self.mode,
-                    )
+                    if self.use_bf16:
+                        with self.autocast, sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+                            pred = self.model(
+                                x_src=torch.cat([X_nni, X_eval], dim=0),
+                                y_src=y_nni,
+                                task=self.mode,
+                            )
+                    else:
+                        pred = self.model(
+                            x_src=torch.cat([X_nni, X_eval], dim=0),
+                            y_src=y_nni,
+                            task=self.mode,
+                        )
                 else:
                     pred = self._predict_large_cls(X_nni, X_eval, y_nni)
 
-                pred = pred[..., :self.num_classes] / temperature
+                pred = pred[..., :self.num_classes].float() / temperature
                 pred = torch.nn.functional.softmax(pred, dim=-1)
 
                 pred_list.append(pred.squeeze())
@@ -155,8 +179,8 @@ class TabDPTClassifier(TabDPTEstimator, ClassifierMixin):
     
 
 class TabDPTRegressor(TabDPTEstimator, RegressorMixin):
-    def __init__(self, path: str, inf_batch_size: int = 512, device: str = 'cuda:0'):
-        super().__init__(path=path, mode='reg', inf_batch_size=inf_batch_size, device=device)
+    def __init__(self, path: str, inf_batch_size: int = 512, device: str = 'cuda:0', use_bf16: bool = True, compile: bool = False):
+        super().__init__(path=path, mode='reg', inf_batch_size=inf_batch_size, device=device, use_bf16=use_bf16, compile=compile)
 
     def predict(self, X: np.ndarray, context_size: int = 128):
         train_x, train_y, test_x = self._prepare_prediction(X)
@@ -168,13 +192,21 @@ class TabDPTRegressor(TabDPTEstimator, RegressorMixin):
             y_stds = y_train.std(dim=0) + 1e-6
             y_train = (y_train - y_means) / y_stds
             
-            pred = self.model(
-                x_src=torch.cat([X_train, X_test], dim=0),
-                y_src=y_train,
-                task=self.mode,
-            )
+            if self.use_bf16:
+                with self.autocast, sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+                    pred = self.model(
+                        x_src=torch.cat([X_train, X_test], dim=0),
+                        y_src=y_train,
+                        task=self.mode,
+                    )
+            else:
+                pred = self.model(
+                    x_src=torch.cat([X_train, X_test], dim=0),
+                    y_src=y_train,
+                    task=self.mode,
+                )
             
-            return (pred * y_stds + y_means).squeeze().detach().cpu().numpy()
+            return (pred.float() * y_stds + y_means).squeeze().detach().cpu().numpy()
         else:
             pred_list = []
             for b in range(math.ceil(len(self.X_test) / self.inf_batch_size)):
@@ -199,13 +231,21 @@ class TabDPTRegressor(TabDPTEstimator, RegressorMixin):
                 y_stds = y_nni.std(dim=0) + 1e-6
                 y_nni = (y_nni - y_means) / y_stds
                 
-                pred = self.model(
-                    x_src=torch.cat([X_nni, X_eval], dim=0),
-                    y_src=y_nni,
-                    task=self.mode,
-                )
+                if self.use_bf16:
+                    with self.autocast, sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+                        pred = self.model(
+                            x_src=torch.cat([X_nni, X_eval], dim=0),
+                            y_src=y_nni,
+                            task=self.mode,
+                        )
+                else:
+                    pred = self.model(
+                        x_src=torch.cat([X_nni, X_eval], dim=0),
+                        y_src=y_nni,
+                        task=self.mode,
+                    )
 
-                pred = pred.squeeze() * y_stds + y_means
+                pred = pred.float().squeeze() * y_stds + y_means
                 pred_list.append(pred)
 
             return torch.cat(pred_list).squeeze().detach().cpu().numpy()

--- a/tabdpt.py
+++ b/tabdpt.py
@@ -2,7 +2,6 @@ import torch
 from torch.nn.attention import SDPBackend, sdpa_kernel
 import numpy as np
 import math
-from tqdm import trange
 import random
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.utils.validation import check_is_fitted
@@ -132,7 +131,7 @@ class TabDPTClassifier(TabDPTEstimator, ClassifierMixin):
             return pred.squeeze(1).detach().cpu().numpy()
         else:
             pred_list = []
-            for b in trange(math.ceil(len(self.X_test) / self.inf_batch_size)):
+            for b in range(math.ceil(len(self.X_test) / self.inf_batch_size)):
                 start = b * self.inf_batch_size
                 end = min(len(self.X_test), (b + 1) * self.inf_batch_size)
 

--- a/tabdpt.py
+++ b/tabdpt.py
@@ -43,8 +43,8 @@ class TabDPTEstimator(BaseEstimator):
         self.y_train = y
         self.is_fitted_ = True
         if self.use_bf16:
+            # When using bf16, we will also use flash_attention by default
             self.autocast = torch.autocast(device_type='cuda', dtype=torch.bfloat16)
-
         if self.compile:
             self.model = torch.compile(self.model)
         

--- a/tabdpt_model.py
+++ b/tabdpt_model.py
@@ -1,26 +1,58 @@
 import torch
 import torch.nn as nn
-from torch.nn import TransformerEncoderLayer
-
+import torch.nn.functional as F
 from utils import maskmean, maskstd, normalize_data, clip_outliers, seed_everything
 
+class TransformerEncoderLayer(nn.Module):
+    def __init__(self, embed_dim, num_heads, ff_dim):
+        super().__init__()
+        bias = True  # Set bias=True to match the original model
+        self.embed_dim = embed_dim
+        self.head_dim = embed_dim // num_heads
+        self.num_heads = num_heads
+        self.kv_proj = nn.Linear(embed_dim, 2 * embed_dim, bias=bias)
+        self.q_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+        self.attn_norm = nn.LayerNorm(embed_dim)
+        self.ff_norm = nn.LayerNorm(embed_dim)
+        self.ff = nn.Sequential(
+            nn.Linear(embed_dim, ff_dim),
+            nn.GELU(),
+            nn.Linear(ff_dim, embed_dim)
+        )
+
+    def forward(self, x, eval_pos):
+        # x = x.transpose(0, 1)  # Transpose to (batch_size, seq_length, embed_dim)
+        B, L, _ = x.size()
+        h = self.attn_norm(x)
+        q = self.q_proj(h)
+        k, v = self.kv_proj(h[:, :eval_pos]).chunk(2, dim=-1)
+        q = q.view(B, L, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k.view(B, eval_pos, self.num_heads, self.head_dim).transpose(1, 2)
+        v = v.view(B, eval_pos, self.num_heads, self.head_dim).transpose(1, 2)
+        attn = F.scaled_dot_product_attention(q, k, v).transpose(1, 2)
+        attn = self.out_proj(attn.reshape(B, L, self.embed_dim))
+        x = x + attn
+        x = x + self.ff(self.ff_norm(x))
+        return x#.transpose(0, 1)  # Transpose back to (seq_length, batch_size, embed_dim)
 
 class TabDPTModel(nn.Module):
     def __init__(self, dropout: float, n_out: int, nhead: int, nhid: int, ninp: int, nlayers: int, norm_first: bool, num_features: int):
         super().__init__()
         self.n_out = n_out
-        self.transformer_encoder = nn.ModuleList(
-            [
-                TransformerEncoderLayer(activation="gelu", d_model=ninp, dim_feedforward=nhid, dropout=dropout, nhead=nhead, norm_first=norm_first)
-                for _ in range(nlayers)
-            ]
-        )
         self.num_features = num_features
         self.encoder = nn.Linear(num_features, ninp)
         self.y_encoder = nn.Linear(1, ninp)
         self.cls_head = nn.Sequential(nn.Linear(ninp, nhid), nn.GELU(), nn.Linear(nhid, n_out))
         self.reg_head = nn.Sequential(nn.Linear(ninp, nhid), nn.GELU(), nn.Linear(nhid, 1))
         self.task2head = {'cls': self.cls_head, 'reg': self.reg_head}
+        # self.task2head = nn.ModuleDict({'cls': self.cls_head, 'reg': self.reg_head})
+        self.transformer_encoder = nn.ModuleList(
+            [
+                TransformerEncoderLayer(embed_dim=ninp, num_heads=nhead, ff_dim=nhid)
+                for _ in range(nlayers)
+            ]
+        )
 
     @torch.no_grad()
     def forward(
@@ -30,10 +62,11 @@ class TabDPTModel(nn.Module):
         task: str,
     ) -> torch.Tensor:
         eval_pos = y_src.shape[0]
+
         x_src = normalize_data(x_src, -1 if self.training else eval_pos)
         x_src = clip_outliers(x_src, -1 if self.training else eval_pos, n_sigma=10)
-
         x_src = torch.nan_to_num(x_src, nan=0)
+
         x_src = self.encoder(x_src)
 
         mean = (x_src**2).mean(dim=-1, keepdim=True)
@@ -43,14 +76,13 @@ class TabDPTModel(nn.Module):
         y_src = self.y_encoder(y_src.unsqueeze(-1))
         train_x = x_src[:eval_pos] + y_src
         src = torch.cat([train_x, x_src[eval_pos:]], 0)
-        condition = torch.arange(src.shape[0]).to(src.device) >= eval_pos
-        attention_mask = condition.repeat(src.shape[0], 1)
 
+        src = src.transpose(0, 1)
         for layer in self.transformer_encoder:
-            src = layer(src, attention_mask)
+            src = layer(src, eval_pos)
         pred = self.task2head[task](src)
 
-        return pred[eval_pos:]
+        return pred[:, eval_pos:].transpose(0, 1)
 
     @classmethod
     def load(cls, model_state, config):
@@ -65,9 +97,71 @@ class TabDPTModel(nn.Module):
             num_features=config['model']['max_num_features'],
         )
 
+        # Remove any module prefixes if necessary
         module_prefix = '_orig_mod.'
         model_state = {k.replace(module_prefix, ''): v for k, v in model_state.items()}
-        model.load_state_dict(model_state)
+
+        # Mapping function to convert state_dict keys
+        def map_state_dict(original_state_dict, model):
+            new_state_dict = {}
+            for key, value in original_state_dict.items():
+                if key.startswith('transformer_encoder.'):
+                    # Handle transformer encoder layers
+                    parts = key.split('.')
+                    layer_idx = parts[1]
+                    sub_module = parts[2]
+                    param_name = '.'.join(parts[3:])
+                    if sub_module == 'self_attn':
+                        if param_name == 'in_proj_weight':
+                            in_proj_weight = value
+                            embed_dim = model.transformer_encoder[int(layer_idx)].embed_dim
+                            q_proj_weight = in_proj_weight[:embed_dim, :]
+                            k_proj_weight = in_proj_weight[embed_dim:2*embed_dim, :]
+                            v_proj_weight = in_proj_weight[2*embed_dim:, :]
+                            kv_proj_weight = torch.cat([k_proj_weight, v_proj_weight], dim=0)
+                            new_state_dict[f'transformer_encoder.{layer_idx}.q_proj.weight'] = q_proj_weight
+                            new_state_dict[f'transformer_encoder.{layer_idx}.kv_proj.weight'] = kv_proj_weight
+                        elif param_name == 'in_proj_bias':
+                            in_proj_bias = value
+                            embed_dim = model.transformer_encoder[int(layer_idx)].embed_dim
+                            q_proj_bias = in_proj_bias[:embed_dim]
+                            k_proj_bias = in_proj_bias[embed_dim:2*embed_dim]
+                            v_proj_bias = in_proj_bias[2*embed_dim:]
+                            kv_proj_bias = torch.cat([k_proj_bias, v_proj_bias], dim=0)
+                            new_state_dict[f'transformer_encoder.{layer_idx}.q_proj.bias'] = q_proj_bias
+                            new_state_dict[f'transformer_encoder.{layer_idx}.kv_proj.bias'] = kv_proj_bias
+                        elif param_name == 'out_proj.weight':
+                            new_state_dict[f'transformer_encoder.{layer_idx}.out_proj.weight'] = value
+                        elif param_name == 'out_proj.bias':
+                            new_state_dict[f'transformer_encoder.{layer_idx}.out_proj.bias'] = value
+                    elif sub_module == 'linear1':
+                        if param_name == 'weight':
+                            new_state_dict[f'transformer_encoder.{layer_idx}.ff.0.weight'] = value
+                        elif param_name == 'bias':
+                            new_state_dict[f'transformer_encoder.{layer_idx}.ff.0.bias'] = value
+                    elif sub_module == 'linear2':
+                        if param_name == 'weight':
+                            new_state_dict[f'transformer_encoder.{layer_idx}.ff.2.weight'] = value
+                        elif param_name == 'bias':
+                            new_state_dict[f'transformer_encoder.{layer_idx}.ff.2.bias'] = value
+                    elif sub_module == 'norm1':
+                        if param_name == 'weight':
+                            new_state_dict[f'transformer_encoder.{layer_idx}.attn_norm.weight'] = value
+                        elif param_name == 'bias':
+                            new_state_dict[f'transformer_encoder.{layer_idx}.attn_norm.bias'] = value
+                    elif sub_module == 'norm2':
+                        if param_name == 'weight':
+                            new_state_dict[f'transformer_encoder.{layer_idx}.ff_norm.weight'] = value
+                        elif param_name == 'bias':
+                            new_state_dict[f'transformer_encoder.{layer_idx}.ff_norm.bias'] = value
+                else:
+                    # Copy other parameters directly
+                    new_state_dict[key] = value
+            return new_state_dict
+
+        # Map the state_dict to the new model
+        new_state_dict = map_state_dict(model_state, model)
+        model.load_state_dict(new_state_dict)
         model.to(config['env']['device'])
         model.eval()
         return model

--- a/tabdpt_model.py
+++ b/tabdpt_model.py
@@ -45,7 +45,6 @@ class TabDPTModel(nn.Module):
         self.cls_head = nn.Sequential(nn.Linear(ninp, nhid), nn.GELU(), nn.Linear(nhid, n_out))
         self.reg_head = nn.Sequential(nn.Linear(ninp, nhid), nn.GELU(), nn.Linear(nhid, 1))
         self.task2head = {'cls': self.cls_head, 'reg': self.reg_head}
-        # self.task2head = nn.ModuleDict({'cls': self.cls_head, 'reg': self.reg_head})
         self.transformer_encoder = nn.ModuleList(
             [
                 TransformerEncoderLayer(embed_dim=ninp, num_heads=nhead, ff_dim=nhid)


### PR DESCRIPTION
Pull request to enable 
1) bf16 mixed precision, 2) flash attention kernels and 3) model compilation.
1) only requires adding an autocast and a context, 3) is a simple flag.
2) is more complex. As optimized sdpa kernels don't work for all masks, we reframe the context/queries TabPFN-style attention as a cross attention between [context] and [context, queries]. This allows to use full masks, unlocking some optimizations. This requires changing the model and the way the weights are loaded.
