### PR TITLE
Store weights on Git LFS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-checkpoints/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ To run `TabDPT`, install the following packages:
 - `scikit-learn`
 - `faiss`
 
-You need to also download the [weights below](#model-weights-download).
-
 ### Update December 2024
 Added support for flash attention (with bf16 precision) and compile flag. Both are enabled to True by default and should lead to a significant speed-up.
 
+### Update January 2025
+Weights are now stored on Git LFS, at the path `checkpoints/tabdpt_76M.ckpt`, instead of Google drive.
 
 ## Example Usage 1
 ```
@@ -46,10 +46,6 @@ model.fit(X_train, y_train)
 y_pred = model.predict(X_test, context_size=1024)
 print(r2_score(y_test, y_pred))
 ```
-
-## Model Weights Download
-
-[Download TabDPT 76M model weights](https://drive.google.com/file/d/1v-kAFXMaBWmK1Kk6hLaDDlckdYLTCfV1/view?usp=sharing)
 
 ## Roadmap
 - [ ] Release other model sizes

--- a/checkpoints/.gitattributes
+++ b/checkpoints/.gitattributes
@@ -1,0 +1,1 @@
+tabdpt_76M.ckpt filter=lfs diff=lfs merge=lfs -text

--- a/checkpoints/tabdpt_76M.ckpt
+++ b/checkpoints/tabdpt_76M.ckpt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d002b557cf37ff038d209ebfc515be57f92a37ef7b1c3ab5268b39831b47658
+size 312440778


### PR DESCRIPTION
Store weights on Git LFS instead of Google Drive, updating the README and .gitignore accordingly