### PR TITLE
Simple fixes to `pad_x` and `flash_context` functions

### DIFF
--- a/src/tabdpt/utils.py
+++ b/src/tabdpt/utils.py
@@ -30,7 +30,8 @@ def flash_context(func):
             assert torch.cuda.is_available(), "FlashAttention requires CUDA support"
             bf_support = torch.cuda.get_device_capability()[0] >= 8
             dtype = torch.bfloat16 if bf_support else torch.float16
-            with torch.autocast(device_type='cuda', dtype=dtype), sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+            device_type = f"cuda:{torch.cuda.current_device()}"
+            with torch.autocast(device_type=device_type, dtype=dtype), sdpa_kernel(SDPBackend.FLASH_ATTENTION):
                 return func(self, *args, **kwargs)
         else:
             return func(self, *args, **kwargs)


### PR DESCRIPTION
1. In `pad_x`, there can be cases where the `num_features` parameter (i.e., the number of final columns after padding) is less than `n_features` (which is the current number of columns). Instead of handling it outside of this function, we can simply add an if-else condition.

2. In `flash_context`, the device is always set to `cuda`. However, in multi-GPU settings, this can cause issues. Instead, we can use `torch.cuda.current_device()` to only use the current device for the current process.