### PR TITLE
Remove Git LFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ Please take a look at `tests/cls_example.py` and `tests/reg_example.py`
 For better performance, please increase `context_size` or increase `n_ensembles` to trade off speed and accuracy
 
 ## Updates
-#### Update January 2025
-Weights are now stored on Git LFS, at the path `checkpoints/tabdpt_76M.ckpt`, in addition to Google drive.
-Please do `git lfs pull` in order to get the latest weights inside `checkpoints` folder.
 
 #### Update December 2024
 Added support for flash attention (with bf16 precision) and compile flag. Both are enabled to True by default and should lead to a significant speed-up.

--- a/checkpoints/.gitattributes
+++ b/checkpoints/.gitattributes
@@ -1,1 +1,0 @@
-tabdpt_76M.ckpt filter=lfs diff=lfs merge=lfs -text

--- a/checkpoints/tabdpt_76M.ckpt
+++ b/checkpoints/tabdpt_76M.ckpt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7d002b557cf37ff038d209ebfc515be57f92a37ef7b1c3ab5268b39831b47658
-size 312440778


### PR DESCRIPTION
Removing references to Git LFS since gdown works fine, plus we hit our cap on the LFS internally.