### PR TITLE
Anthony/regression squeeze hotfix

### DIFF
--- a/src/tabdpt/regressor.py
+++ b/src/tabdpt/regressor.py
@@ -68,7 +68,7 @@ class TabDPTRegressor(TabDPTEstimator, RegressorMixin):
                     task=self.mode,
                 )
 
-                pred_list.append(pred.squeeze())
+                pred_list.append(pred.squeeze(dim=0))
 
             return torch.cat(pred_list).squeeze().detach().cpu().float().numpy()
 


### PR DESCRIPTION
behaviour of regression is different from classification because it is not outputting for 10 logits. dim=0 is the appropriate choice for regression as it handles batch sizes of 1 or more.

Checked the inference code as well for batch sizes of 1 and it works fine under the current implementation 