### PR TITLE
Limit faiss-cpu version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license-files = ["LICEN[CS]E*"]
 requires-python = ">=3.10"
 dependencies = [
     "appdirs>=1.4.4,<2.0",
-    "faiss-cpu>=1.11.0,<2.0",
+    "faiss-cpu>=1.11.0,<1.13.0",
     "gdown>=5.2.0,<6.0",
     "huggingface-hub>=0.33.2,<1.0",
     "numpy>=2.1.0,<3.0",


### PR DESCRIPTION
The way we set the faiss seed no longer works and the lack of Python API docs means it'll take some looking into to find another way, so just adding this as a hotfix for now