### PR TITLE
Fix predict_proba output dims for single sample

### DIFF
--- a/src/tabdpt/classifier.py
+++ b/src/tabdpt/classifier.py
@@ -144,6 +144,9 @@ class TabDPTClassifier(TabDPTEstimator, ClassifierMixin):
                 pred_list.append(pred.squeeze(dim=0))
             pred_val = torch.cat(pred_list, dim=0).squeeze().detach().cpu().float().numpy()
 
+        # Ensure pred_val is always (n_samples, n_classes) even for a single sample.
+        if pred_val.ndim == 1:
+            pred_val = pred_val[None, :]  # (n_classes,) -> (1, n_classes)
         return pred_val
 
     def ensemble_predict_proba(


### PR DESCRIPTION
Resolves #63

Now outputs will always have dimensions (n_samples, n_classes) when calling `predict_proba`, whereas previously if the number of samples was 1 it would be (n_classes,) dimension.

An alternative solution in case the authors want to support X being passed as a 1d array and in this case returning 1d output, this check could be made conditional on `X.ndim > 1`.

I recommend the authors release a new micro release (v1.1.12) after merging this PR to fix TabDPT in AutoGluon 1.5.