### PR TITLE
Make regression output shape consistent when X_test.shape[0] == 1

### DIFF
--- a/src/tabdpt/regressor.py
+++ b/src/tabdpt/regressor.py
@@ -62,7 +62,7 @@ class TabDPTRegressor(TabDPTEstimator, RegressorMixin):
                 task=self.mode,
             )
 
-            return pred.float().squeeze().detach().cpu().float().numpy()
+            return pred.float().squeeze(1).detach().cpu().float().numpy()
         else:
             pred_list = []
             for b in range(math.ceil(len(self.X_test) / self.inf_batch_size)):
@@ -89,7 +89,7 @@ class TabDPTRegressor(TabDPTEstimator, RegressorMixin):
 
                 pred_list.append(pred.squeeze(dim=0))
 
-            return torch.cat(pred_list).squeeze().detach().cpu().float().numpy()
+            return torch.cat(pred_list).detach().cpu().float().numpy()
 
     def _ensemble_predict(
             self,


### PR DESCRIPTION
Tested by modifying reg_example.py to verify that the shape remains the same for the current X_test values, but is an array when X_test.shape[0] == 1, both when using retrieval and not using retrieval.