### PR TITLE
Align n_ensembles handling between classifier predict functions

### DIFF
--- a/src/tabdpt/classifier.py
+++ b/src/tabdpt/classifier.py
@@ -158,6 +158,9 @@ class TabDPTClassifier(TabDPTEstimator, ClassifierMixin):
         permute_classes: bool = True,
         seed: int | None = None,
     ):
+        if n_ensembles == 1:
+            return self.predict_proba(X, temperature=temperature, context_size=context_size, seed=seed)
+
         logit_cumsum = None
         for inner_seed in self._get_ensemble_iterator(n_ensembles, seed):
             inner_seed = int(inner_seed)


### PR DESCRIPTION
Allows using TabDPTClassifier.ensemble_predict_proba as a single entry point for probabilistic outputs, matching the behaviour of predict(). This will affect inference behaviour slightly, but only slightly for an unusual case (using ensemble_predict_proba with n_ensembles==1 will no longer shuffle columns)

For a future major update, we could consider exposing this behaviour for predict_proba, more closely matching sklearn expectations, but it might be too risky a change for existing code.