### PR TITLE
Always use inf_batch_size during inference, even without retrieval

### DIFF
--- a/src/tabdpt/classifier.py
+++ b/src/tabdpt/classifier.py
@@ -13,7 +13,7 @@ from .utils import generate_random_permutation, pad_x
 class TabDPTClassifier(TabDPTEstimator, ClassifierMixin):
     def __init__(
         self,
-        inf_batch_size: int = None,
+        inf_batch_size: int | None = None,
         normalizer: Literal["standard", "minmax", "robust", "power", "quantile-uniform", "quantile-normal", "log1p"] | None
             = "standard",
         missing_indicators: bool = False,

--- a/src/tabdpt/classifier.py
+++ b/src/tabdpt/classifier.py
@@ -13,7 +13,7 @@ from .utils import generate_random_permutation, pad_x
 class TabDPTClassifier(TabDPTEstimator, ClassifierMixin):
     def __init__(
         self,
-        inf_batch_size: int = 512,
+        inf_batch_size: int = None,
         normalizer: Literal["standard", "minmax", "robust", "power", "quantile-uniform", "quantile-normal", "log1p"] | None
             = "standard",
         missing_indicators: bool = False,
@@ -89,26 +89,30 @@ class TabDPTClassifier(TabDPTEstimator, ClassifierMixin):
             train_x = train_x[:, feat_perm]
             test_x = test_x[:, feat_perm]
 
+        pred_list = []
         if context_size >= self.n_instances:
             X_train = pad_x(train_x[None, :, :], self.max_features).to(self.device)
             X_test = pad_x(test_x[None, :, :], self.max_features).to(self.device)
             y_train = train_y[None, :].float()
 
-            if self.num_classes <= self.max_num_classes:
-                pred = self.model(
-                    x_src=torch.cat([X_train, X_test], dim=1),
-                    y_src=y_train.unsqueeze(-1),
-                    task=self.mode,
-                )
-            else:
-                pred = self._predict_large_cls(X_train, X_test, y_train)
+            for b in range(math.ceil(len(self.X_test) / self.inf_batch_size)):
+                start = b * self.inf_batch_size
+                end = min(len(self.X_test), (b + 1) * self.inf_batch_size)
 
-            if not return_logits:
-                pred = pred[..., :self.num_classes] / temperature
-                pred = torch.nn.functional.softmax(pred.float(), dim=-1)
-            pred_val = pred.float().squeeze().detach().cpu().numpy()
+                if self.num_classes <= self.max_num_classes:
+                    pred = self.model(
+                        x_src=torch.cat([X_train, X_test[:, start:end]], dim=1),
+                        y_src=y_train.unsqueeze(-1),
+                        task=self.mode,
+                    )
+                else:
+                    pred = self._predict_large_cls(X_train, X_test[:, start:end], y_train)
+
+                if not return_logits:
+                    pred = pred[..., :self.num_classes] / temperature
+                    pred = torch.nn.functional.softmax(pred.float(), dim=-1)
+                pred_list.append(pred.squeeze(1))
         else:
-            pred_list = []
             for b in range(math.ceil(len(self.X_test) / self.inf_batch_size)):
                 start = b * self.inf_batch_size
                 end = min(len(self.X_test), (b + 1) * self.inf_batch_size)
@@ -142,7 +146,8 @@ class TabDPTClassifier(TabDPTEstimator, ClassifierMixin):
                     pred /= pred.sum(axis=-1, keepdims=True)  # numerical stability
 
                 pred_list.append(pred.squeeze(dim=0))
-            pred_val = torch.cat(pred_list, dim=0).squeeze().detach().cpu().float().numpy()
+
+        pred_val = torch.cat(pred_list, dim=0).detach().cpu().float().numpy()
 
         # Ensure pred_val is always (n_samples, n_classes) even for a single sample.
         if pred_val.ndim == 1:

--- a/src/tabdpt/estimator.py
+++ b/src/tabdpt/estimator.py
@@ -1,5 +1,6 @@
 import json
 from typing import Literal
+import warnings
 
 import numpy as np
 import torch
@@ -18,7 +19,6 @@ from .utils import convert_to_torch_tensor, Log1pScaler, generate_random_permuta
 _VERSION = "1_1"
 _MODEL_NAME = f"tabdpt{_VERSION}.safetensors"
 _HF_REPO_ID = "Layer6/TabDPT"
-CPU_INF_BATCH = 16
 
 
 class TabDPTEstimator(BaseEstimator):
@@ -33,7 +33,7 @@ class TabDPTEstimator(BaseEstimator):
     def __init__(
         self,
         mode: Literal["cls", "reg"],
-        inf_batch_size: int = 512,
+        inf_batch_size: int = None,
         normalizer: Literal["standard", "minmax", "robust", "power", "quantile-uniform", "quantile-normal", "log1p"] | None
             = "standard",
         missing_indicators: bool = False,
@@ -51,7 +51,7 @@ class TabDPTEstimator(BaseEstimator):
         Args:
             mode: Defines what mode the estimator is
                 "cls" is classification, "reg" is regression
-            inf_batch_size: The batch size for inferencing
+            inf_batch_size: The batch size for inference. Defaults to 512 on CUDA and 16 on CPU.
             normalizer: Specifies normalization used for preprocessing before retrieval. Note that
                 the model performs additional normalization in its forward function. By default the
                 scikit-learn StandardScaler is used, which matches model training. Other options are:
@@ -79,7 +79,18 @@ class TabDPTEstimator(BaseEstimator):
         """
         self.mode = mode
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
-        self.inf_batch_size = inf_batch_size if self.device == "cuda" else min(inf_batch_size, CPU_INF_BATCH)
+        if inf_batch_size is None:
+            if self.device == "cpu":
+                self.inf_batch_size = 16
+                warnings.warn(
+                    "Using TabDPT on CPU, so setting inf_batch_size to 16. This helps to prevent "
+                    "OOMs but can result in excessively slow inference, especially if retrieval is "
+                    "not being used. Set inf_batch_size explicitly to suppress this warning."
+                )
+            else:
+                self.inf_batch_size = 512
+        else:
+            self.inf_batch_size = inf_batch_size
         self.use_flash = use_flash and self.device == "cuda"
         self.missing_indicators = missing_indicators
 

--- a/src/tabdpt/estimator.py
+++ b/src/tabdpt/estimator.py
@@ -33,7 +33,7 @@ class TabDPTEstimator(BaseEstimator):
     def __init__(
         self,
         mode: Literal["cls", "reg"],
-        inf_batch_size: int = None,
+        inf_batch_size: int | None = None,
         normalizer: Literal["standard", "minmax", "robust", "power", "quantile-uniform", "quantile-normal", "log1p"] | None
             = "standard",
         missing_indicators: bool = False,

--- a/src/tabdpt/regressor.py
+++ b/src/tabdpt/regressor.py
@@ -12,7 +12,7 @@ from .utils import generate_random_permutation, pad_x
 class TabDPTRegressor(TabDPTEstimator, RegressorMixin):
     def __init__(
         self,
-        inf_batch_size: int = None,
+        inf_batch_size: int | None = None,
         normalizer: Literal["standard", "minmax", "robust", "power", "quantile-uniform", "quantile-normal", "log1p"] | None
             = "standard",
         missing_indicators: bool = False,

--- a/src/tabdpt/regressor.py
+++ b/src/tabdpt/regressor.py
@@ -12,7 +12,7 @@ from .utils import generate_random_permutation, pad_x
 class TabDPTRegressor(TabDPTEstimator, RegressorMixin):
     def __init__(
         self,
-        inf_batch_size: int = 512,
+        inf_batch_size: int = None,
         normalizer: Literal["standard", "minmax", "robust", "power", "quantile-uniform", "quantile-normal", "log1p"] | None
             = "standard",
         missing_indicators: bool = False,
@@ -52,19 +52,25 @@ class TabDPTRegressor(TabDPTEstimator, RegressorMixin):
             train_x = train_x[:, feat_perm]
             test_x = test_x[:, feat_perm]
 
+        pred_list = []
         if context_size >= self.n_instances:
             X_train = pad_x(train_x[None, :, :], self.max_features).to(self.device)
             X_test = pad_x(test_x[None, :, :], self.max_features).to(self.device)
             y_train = train_y[None, :].float()
-            pred = self.model(
-                x_src=torch.cat([X_train, X_test], dim=1),
-                y_src=y_train.unsqueeze(-1),
-                task=self.mode,
-            )
 
-            return pred.float().squeeze(1).detach().cpu().float().numpy()
+            for b in range(math.ceil(len(self.X_test) / self.inf_batch_size)):
+                start = b * self.inf_batch_size
+                end = min(len(self.X_test), (b + 1) * self.inf_batch_size)
+
+                pred = self.model(
+                    x_src=torch.cat([X_train, X_test[:, start:end]], dim=1),
+                    y_src=y_train.unsqueeze(-1),
+                    task=self.mode,
+                )
+                pred_list.append(pred.squeeze(1))
+
+            return torch.cat(pred_list).detach().cpu().float().numpy()
         else:
-            pred_list = []
             for b in range(math.ceil(len(self.X_test) / self.inf_batch_size)):
                 start = b * self.inf_batch_size
                 end = min(len(self.X_test), (b + 1) * self.inf_batch_size)


### PR DESCRIPTION
Ensures we don't OOM on very large test sets. Downside is that it'll slow down inference when retrieval isn't used.

Also use inf_batch_size on CPU when explicitly specified, and warn user to set it explicitly instead of silently overriding with a really low and slow value (this has made it look unexpectedly slow for me when testing on CPU before).

Also get rid of the last `squeeze()` without a dim specified.

In a future update, we should do the following breaking change, since memory usage is `O(context_size + inf_batch_size)` without retrieval but `O(context_size * inf_batch_size)` with retrieval:
- Move inf_batch_size to be a predict parameter
- If `None`, set the default based on both the device and whether retrieval is used, suggested values:
    - GPU+No retrieval: 1M
    - GPU+Retrieval: 512
    - CPU+No Retrieval:  32k
    - CPU+Retrieval: 16

Probably only needs 1 review, whoever's free.